### PR TITLE
Fix db endpoint - update deprecated db endpoints

### DIFF
--- a/dags/sentinel-2_indexing.py
+++ b/dags/sentinel-2_indexing.py
@@ -34,7 +34,7 @@ DEFAULT_ARGS = {
     "retry_delay": timedelta(minutes=5),
     "env_vars": {
         # TODO: Pass these via templated params in DAG Run
-        "DB_HOSTNAME": "database-write.local",
+        "DB_HOSTNAME": "db-writer",
         "DB_DATABASE": "africa",
         "WMS_CONFIG_PATH": "/env/config/ows_cfg.py",
         "DATACUBE_OWS_CFG": "config.ows_cfg.ows_cfg"


### PR DESCRIPTION
```
-            value: database-write.local:5432
+            value: db-writer:5432
```
`database-write.local` is being deprecated and is replaced by `db-writer`