### PR TITLE
update indexing dags to run every 3hours

### DIFF
--- a/dags/landsat_indexing.py
+++ b/dags/landsat_indexing.py
@@ -69,7 +69,7 @@ dag = DAG(
     dag_id=DAG_NAME,
     doc_md=__doc__,
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 */1 * * *",
+    schedule_interval="0 */3 * * *",
     catchup=False,
     tags=["k8s", "landsat"],
 )

--- a/dags/sentinel-1_indexing.py
+++ b/dags/sentinel-1_indexing.py
@@ -70,7 +70,7 @@ dag = DAG(
     dag_id=DAG_NAME,
     doc_md=__doc__,
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 */1 * * *",
+    schedule_interval="20 */3 * * *",
     catchup=False,
     tags=["k8s", "sentinel-1"],
 )

--- a/dags/sentinel-2_indexing.py
+++ b/dags/sentinel-2_indexing.py
@@ -70,7 +70,7 @@ dag = DAG(
     dag_id=DAG_NAME,
     doc_md=__doc__,
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 */1 * * *",
+    schedule_interval="40 */3 * * *",
     catchup=False,
     tags=["k8s", "sentinel-2"],
 )


### PR DESCRIPTION
update indexing dags to run every 3hours as I see too many indexing pods are running. Also running too frequently can overwhelm database.